### PR TITLE
ui: Set default refresh rate to 60FPS

### DIFF
--- a/include/ui/console.h
+++ b/include/ui/console.h
@@ -44,7 +44,7 @@ OBJECT_DECLARE_SIMPLE_TYPE(QemuFixedTextConsole, QEMU_FIXED_TEXT_CONSOLE)
 #define QEMU_CAPS_LOCK_LED   (1 << 2)
 
 /* in ms */
-#define GUI_REFRESH_INTERVAL_DEFAULT    30
+#define GUI_REFRESH_INTERVAL_DEFAULT    16
 #define GUI_REFRESH_INTERVAL_IDLE     3000
 
 /* Color number is match to standard vga palette */


### PR DESCRIPTION
The default refresh interval is too slow, and causes the VM experience to be unacceptably clunky.